### PR TITLE
Fix prefetching on iOS 14.5 and up

### DIFF
--- a/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
@@ -226,6 +226,27 @@ class FeedUIIntegrationTests: XCTestCase {
         XCTAssertEqual(loader.loadMoreCallCount, 2)
     }
 
+    func test_feedImageView_configuresViewCorrectlyWhenTransitioningFromNearVisibleToVisibleWhileStillPreloadingImage() {
+        let (sut,loader) = makeSUT()
+
+        sut.loadViewIfNeeded()
+        loader.completeFeedLoading(with: [makeImage()])
+
+        sut.simulateFeedImageViewNearVisible(at: 0)
+        let view = sut.simulateFeedImageViewVisible(at: 0)
+
+        XCTAssertEqual(view?.renderedImage, nil, "Expected no rendered image when view becomes visible while still preloading")
+        XCTAssertEqual(view?.isShowingRetryAction, false, "Expected no retry action when view becomes visible while still preloading")
+        XCTAssertEqual(view?.isShowingImageLoadingIndicator, true, "Expected loading indicator when view becomes visible while still preloading")
+
+        let imageData = UIImage.make(withColor: .red).pngData()!
+        loader.completeImageLoading(with: imageData, at: 0)
+
+        XCTAssertEqual(view?.renderedImage, imageData, "Expected rendered image after image preloads successfully")
+        XCTAssertEqual(view?.isShowingRetryAction, false, "Expected no retry action after image preloads successfullyg")
+        XCTAssertEqual(view?.isShowingImageLoadingIndicator, false, "Expected no loading indicator after image preloads successfully")
+    }
+
     func test_feedImageView_doesNotRenderLoadedImageWhenNotVisibleAnymore() {
         let (sut, loader) = makeSUT()
         sut.loadViewIfNeeded()

--- a/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
@@ -1658,7 +1658,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 12.6;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.distiil.EssentialFeed;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1698,7 +1698,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 12.6;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.distiil.EssentialFeed;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedImageCellController.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedImageCellController.swift
@@ -41,6 +41,8 @@ extension FeedImageCellController: UITableViewDataSource, UITableViewDelegate, U
         cell?.locationContainer.isHidden = !viewModel.hasLocation
         cell?.locationLabel.text = viewModel.location
         cell?.descriptionLabel.text = viewModel.description
+        cell?.feedImageContainer.isShimmering = true
+        cell?.imageRetryButton.isHidden = true
 
         cell?.onRetry = { [weak self] in
             self?.delegate.didRequestImage()


### PR DESCRIPTION
Reset cells on `cellForRowAt` because prefetching is likely to start at the same time cells will become visible, and it could lead to race conditions in the cell configuration